### PR TITLE
Fixed saveElective error

### DIFF
--- a/src/SELECTive/Elective.java
+++ b/src/SELECTive/Elective.java
@@ -250,7 +250,7 @@ public class Elective {
                 this.program.toString(),
                 keywordString(),
                 this.lectureDay.toString(),
-                this.block.toString(),
+		Integer.toString(this.block),
                 Long.toString(this.lecturerId),
         };
 


### PR DESCRIPTION
Changed "this.block.toString()" into "Integer.toString(this.block)" since toString cannot be used for integer primitives